### PR TITLE
Advanced additional content

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Parameters defined in MSBuild using `MsDeployDeclareParameters` or `MSDeployPara
 
 The default behavior is to include all project items marked as `Content` (in their file properties). If your builds dynamically generate files, they can be included in the publish using standard WPP extensibility. 
 
-To include additional content by glob, define `AdditionalFilesForPackagingFromHelixModules`:
+To include additional content under the project directory by glob, define `AdditionalFilesForPackagingFromHelixModules`:
 
 ```xml
 <!-- In ProjectName.wpp.targets or PublishProfile.wpp.targets -->
@@ -144,7 +144,29 @@ To include additional content by glob, define `AdditionalFilesForPackagingFromHe
 </ItemGroup>
 ```
 
-Remapping the content to different output paths is currently not supported.
+For advanced scenarios, such as when the source and target directories don't match exactly, specify both a `SourcePath` and `TargetPath`. `TargetPath` can refer to content metadata using the `^(Metadata)` syntax and can also refer to any metadata from the relative module using `^(HelixModule.Metadata)`:
+
+```xml
+<!-- In ProjectName.wpp.targets or PublishProfile.wpp.targets -->
+<ItemGroup>
+  <AdditionalFilesForPackagingFromHelixModules Include="Serialization">
+    <SourcePath>..\serialization\**\*.yml</SourcePath>
+    <TargetPath>App_Data\unicorn\^(HelixModule.Filename)\^(RecursiveDir)^(Filename)^(Extension)</TargetPath>
+  </AdditionalFilesForPackagingFromHelixModules>
+</ItemGroup>
+```
+
+A list of standard file metadata names can be found at [MSBuild well-known item metadata](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-well-known-item-metadata), and additional module metadata can be specified with the `ProjectReference`:
+
+
+```xml
+<ItemGroup>
+  <ProjectReference Include="..\Foundation\*\code\*.csproj">
+    <!-- Can be used in a TargetPath using ^(HelixModule.Layer) -->
+    <Layer>Foundation</Layer>
+  </ProjectReference>
+</ItemGroup>
+```
 
 NOTE: Web.config files contained in modules are intentionally skipped to avoid issues with long paths as described by [#9](https://github.com/richardszalay/helix-publishing-pipeline/issues/9). This restriction only affects Web.config files, not Sitecore config files, and will be removed once a suitable workaround is place.
 

--- a/src/targets/Helix.Publishing.Plugins/CollectFilesFromHelixModules.Additional.targets
+++ b/src/targets/Helix.Publishing.Plugins/CollectFilesFromHelixModules.Additional.targets
@@ -1,13 +1,30 @@
 <Project>
-  <Target Name="CollectFilesFromHelixModulesAdditional" Outputs="%(AdditionalFilesForPackagingFromHelixModules.Identity)" DependsOnTargets="CollectHelixModules">
+  <UsingTask TaskName="RichardSzalay.Helix.Publishing.Tasks.ResolveModuleContentTargetPath" 
+    AssemblyFile="$(MSBuildThisFileDirectory)..\RichardSzalay.Helix.Publishing.Tasks.dll"
+    />
+
+  <Target Name="CollectFilesFromHelixModulesAdditional" Outputs="%(HelixModulePaths.Identity)" DependsOnTargets="CollectHelixModules">
 
     <PropertyGroup>
-        <_AdditionalFilesForPackagingFromHelixModulesIdentity>%(AdditionalFilesForPackagingFromHelixModules.Identity)</_AdditionalFilesForPackagingFromHelixModulesIdentity>
+        <_HelixModulePath>%(HelixModulePaths.RootDir)%(HelixModulePaths.Directory)</_HelixModulePath>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(_AdditionalFilesForPackagingFromHelixModulesIdentity)' != ''">
-        <_HelixModuleContentSpecs Include="@(HelixModulePaths -> '%(RootDir)%(Directory)\$(_AdditionalFilesForPackagingFromHelixModulesIdentity)')">
-            <HelixModulePath>%(RootDir)%(Directory)</HelixModulePath>
+    <ItemGroup>
+        <_AdditionalRelativeFilesForPackagingFromHelixModules 
+            Include="@(AdditionalFilesForPackagingFromHelixModules)"
+            Condition="'%(AdditionalFilesForPackagingFromHelixModules.TargetPath)' == ''"
+            />
+
+        <_AdditionalTemplatedFilesForPackagingFromHelixModules 
+            Include="@(AdditionalFilesForPackagingFromHelixModules)"
+            Condition="'%(AdditionalFilesForPackagingFromHelixModules.TargetPath)' != '' and '%(AdditionalFilesForPackagingFromHelixModules.SourcePath)' != ''"
+            />
+    </ItemGroup>
+
+    <ItemGroup>
+        <_HelixModuleContentSpecs Include="@(_AdditionalRelativeFilesForPackagingFromHelixModules -> '$(_HelixModulePath)%(Identity)')" />
+        <_HelixModuleContentSpecs Include="@(_AdditionalTemplatedFilesForPackagingFromHelixModules -> '$(_HelixModulePath)%(SourcePath)')">
+            <TargetPath>%(_AdditionalTemplatedFilesForPackagingFromHelixModules.TargetPath)</TargetPath>
         </_HelixModuleContentSpecs>
     </ItemGroup>
 
@@ -15,9 +32,18 @@
         <Output TaskParameter="Include" ItemName="_HelixModuleContent"/>
     </CreateItem>
 
-    <ItemGroup Condition="'@(_HelixModuleContent)' != ''">
-        <FilesForPackagingFromHelixModules Include="@(_HelixModuleContent)">
-            <DestinationRelativePath>$([MSBuild]::MakeRelative('%(_HelixModuleContent.HelixModulePath)', '%(FullPath)'))</DestinationRelativePath>
+    <ResolveModuleContentTargetPath
+        Module="@(HelixModulePaths)"
+        Content="@(_HelixModuleContent)"
+        TargetPathMetadataName="TargetPath"
+        ModuleMetadataPrefix="HelixModule"
+    >
+        <Output TaskParameter="Output" ItemName="_ResolvedHelixModuleContent"/>
+    </ResolveModuleContentTargetPath>
+
+    <ItemGroup Condition="'@(_ResolvedHelixModuleContent)' != ''">
+        <FilesForPackagingFromHelixModules Include="@(_ResolvedHelixModuleContent)">
+            <DestinationRelativePath>%(TargetPath)</DestinationRelativePath>
             <FromTarget>CollectFilesFromHelixModuleContent</FromTarget>
         </FilesForPackagingFromHelixModules>
     </ItemGroup>

--- a/src/targets/tests/CollectFilesFromHelixModules.Additional.ps1
+++ b/src/targets/tests/CollectFilesFromHelixModules.Additional.ps1
@@ -21,8 +21,12 @@ Describe "CollectFilesFromHelixModules.Additional" {
             "IncludeAdditionalHelixModulesContent" = "true";
         } -TargetName "CollectFilesFromHelixModulesAdditional" -OutputItem "FilesForPackagingFromHelixModules -> '%(DestinationRelativePath)'"
 
-        It "should include matching files" {
+        It "should include matching files added without TargetPath" {
             $result -contains "assets\feature1.js" | Should Be $true
+        }
+
+        It "should include matching files added with TargetPath" {
+            $result -contains "App_Config\Include\HelixBuild.Foundation1.config" | Should Be $true
         }
     }
 

--- a/src/targets/tests/Module.Acceptance.Tests.ps1
+++ b/src/targets/tests/Module.Acceptance.Tests.ps1
@@ -58,6 +58,10 @@ Describe "Module configuration" {
             $packageFiles -contains "assets\feature1.js" | Should Be $true
         }
 
+        It "should include additional module content that have been specified by templated TargetDir" {
+            $packageFiles -contains "App_Data\unicorn\HelixBuild.Feature1\sub\Content1.yml" | Should Be $true
+        }
+
         It "should not include additional module content that have been specified by path from indirect module dependencies" {
             $packageFiles -contains "assets\foundation.js" | Should Be $false
         }

--- a/src/targets/tests/fixtures/default/Projects/HelixBuild.Sample.Web/code/HelixBuild.Sample.Web.wpp.targets
+++ b/src/targets/tests/fixtures/default/Projects/HelixBuild.Sample.Web/code/HelixBuild.Sample.Web.wpp.targets
@@ -5,6 +5,11 @@
 
     <ItemGroup Condition="'$(IncludeAdditionalHelixModulesContent)' == 'true'">
         <AdditionalFilesForPackagingFromHelixModules Include="$([MSBuild]::Escape('assets\**\*'))" />
+
+        <AdditionalFilesForPackagingFromHelixModules Include="Serialization">
+            <SourcePath>..\serialization\**\*.yml</SourcePath>
+            <TargetPath>App_Data\unicorn\^(HelixModule.Filename)\^(RecursiveDir)^(Filename)^(Extension)</TargetPath>
+        </AdditionalFilesForPackagingFromHelixModules>
     </ItemGroup>
 
     <ItemGroup Condition="'$(ExternalWebConfigLocation)' != ''">

--- a/src/tasks/RichardSzalay.Helix.Publishing.Tasks.Tests/FakeTaskItem.cs
+++ b/src/tasks/RichardSzalay.Helix.Publishing.Tasks.Tests/FakeTaskItem.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.Build.Framework;
 
 namespace RichardSzalay.Helix.Publishing.Tasks.Tests
@@ -32,7 +33,10 @@ namespace RichardSzalay.Helix.Publishing.Tasks.Tests
 
         public void CopyMetadataTo(ITaskItem destinationItem)
         {
-            throw new System.NotImplementedException();
+            foreach (var kvp in this.metadata)
+            {
+                destinationItem.SetMetadata(kvp.Key, kvp.Value);
+            }
         }
 
         public string GetMetadata(string metadataName)
@@ -63,6 +67,18 @@ namespace RichardSzalay.Helix.Publishing.Tasks.Tests
         IEnumerator IEnumerable.GetEnumerator()
         {
             return metadata.GetEnumerator();
+        }
+
+        public static ITaskItem FromFilePath(string path)
+        {
+            var item = new FakeTaskItem(path);
+
+            item.SetMetadata("FullPath", path);
+            item.SetMetadata("Directory", Path.GetExtension(path));
+            item.SetMetadata("Filename", Path.GetFileNameWithoutExtension(path));
+            item.SetMetadata("Extension", Path.GetExtension(path));
+
+            return item;
         }
     }
 

--- a/src/tasks/RichardSzalay.Helix.Publishing.Tasks.Tests/ResolveModuleContentTargetPathTests.cs
+++ b/src/tasks/RichardSzalay.Helix.Publishing.Tasks.Tests/ResolveModuleContentTargetPathTests.cs
@@ -1,0 +1,240 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RichardSzalay.Helix.Publishing.Tasks.Tests
+{
+    public class ResolveModuleContentTargetPathTests
+    {
+        private readonly ResolveModuleContentTargetPath sut;
+
+        public ResolveModuleContentTargetPathTests()
+        {
+            sut = new ResolveModuleContentTargetPath()
+            {
+                ModuleMetadataPrefix = "HelixModule",
+                TargetPathMetadataName = "TargetPath",
+                BuildEngine = new FakeBuildEngine()
+            };
+        }
+
+        [Fact]
+        public void Uses_relative_path_when_no_TargetPath_specified()
+        {
+            Test(
+                CreateModuleItem(@"c:\path\to\TestModule.csproj"),
+                new[]
+                {
+                    CreateContentItem(@"c:\path\to\relative\content1.txt"),
+                    CreateContentItem(@"c:\path\to\relative\content2.txt")
+                },
+                success: true,
+                expectedTargetPaths: new[]
+                {
+                    @"relative\content1.txt",
+                    @"relative\content2.txt"
+                }
+            );
+        }
+
+        [Fact]
+        public void Throws_when_no_TargetPath_specified_but_paths_cannot_be_made_relative()
+        {
+            Test(
+                CreateModuleItem(@"c:\path\to\TestModule.csproj"),
+                new[]
+                {
+                    CreateContentItem(@"d:\path\to\relative\content1.txt")
+                },
+                success: false,
+                expectedTargetPaths: new string[0]
+            );
+        }
+
+        [Fact]
+        public void Expands_templated_TargetPath_when_specified()
+        {
+            Test(
+                CreateModuleItem(@"c:\path\to\TestModule.csproj"),
+                new[]
+                {
+                    CreateContentItem(
+                        @"d:\path\to\relative\content1.txt",
+                        new Dictionary<string, string>
+                        {
+                            ["TargetPath"] = @"^(Var1)\^(Var2)",
+                            ["Var1"] = @"Value1",
+                            ["Var2"] = @"Value2"
+                        }
+                    )
+                },
+                success: true,
+                expectedTargetPaths: new []
+                {
+                    @"Value1\Value2"
+                }
+            );
+        }
+
+        [Fact]
+        public void Templated_TargetPath_prefers_content_metadata()
+        {
+            Test(
+                CreateModuleItem(
+                    @"c:\path\to\TestModule.csproj",
+                    new Dictionary<string, string>
+                    {
+                        ["TargetPath"] = @"^(Var1)\^(Var2)",
+                        ["Var1"] = @"Module1",
+                        ["Var2"] = @"Module2"
+                    }
+                ),
+                new[]
+                {
+                    CreateContentItem(
+                        @"d:\path\to\relative\content1.txt",
+                        new Dictionary<string, string>
+                        {
+                            ["TargetPath"] = @"^(Var1)\^(Var2)",
+                            ["Var1"] = @"Value1",
+                            ["Var2"] = @"Value2"
+                        }
+                    )
+                },
+                success: true,
+                expectedTargetPaths: new[]
+                {
+                    @"Value1\Value2"
+                }
+            );
+        }
+        
+        [Fact]
+        public void Templated_TargetPath_uses_module_metadata_when_requested()
+        {
+            Test(
+                CreateModuleItem(
+                    @"c:\path\to\TestModule.csproj",
+                    new Dictionary<string, string>
+                    {
+                        ["Var1"] = @"Module1",
+                        ["Var2"] = @"Module2"
+                    }
+                ),
+                new[]
+                {
+                    CreateContentItem(
+                        @"d:\path\to\relative\content1.txt",
+                        new Dictionary<string, string>
+                        {
+                            ["TargetPath"] = @"^(HelixModule.Filename)\^(HelixModule.Var2)",
+                            ["Var1"] = @"Value1",
+                            ["Var2"] = @"Value2"
+                        }
+                    )
+                },
+                success: true,
+                expectedTargetPaths: new[]
+                {
+                    @"TestModule\Module2"
+                }
+            );
+        }
+
+        [Fact]
+        public void Fails_when_templated_TargetPath_is_not_relative()
+        {
+            Test(
+                CreateModuleItem(@"c:\path\to\TestModule.csproj"),
+                new[]
+                {
+                    CreateContentItem(
+                        @"d:\path\to\relative\content1.txt",
+                        new Dictionary<string, string>
+                        {
+                            ["TargetPath"] = @"..\another\path",
+                            ["Var1"] = @"Value1",
+                            ["Var2"] = @"Value2"
+                        }
+                    )
+                },
+                success: false,
+                expectedTargetPaths: new string[0]
+            );
+        }
+
+        [Fact]
+        public void Fails_when_templated_TargetPath_is_rooted()
+        {
+            Test(
+                CreateModuleItem(@"c:\path\to\TestModule.csproj"),
+                new[]
+                {
+                    CreateContentItem(
+                        @"d:\path\to\relative\content1.txt",
+                        new Dictionary<string, string>
+                        {
+                            ["TargetPath"] = @"c:\another\path",
+                            ["Var1"] = @"Value1",
+                            ["Var2"] = @"Value2"
+                        }
+                    )
+                },
+                success: false,
+                expectedTargetPaths: new string[0]
+            );
+        }
+
+        private void Test(ITaskItem moduleItem, ITaskItem[] contentItems, bool success, string[] expectedTargetPaths)
+        {
+            sut.Module = moduleItem;
+            sut.Content = contentItems;
+            var result = sut.Execute();
+
+            Assert.Equal(success, result);
+
+            if (success)
+            {
+                Assert.Equal(
+                    expectedTargetPaths,
+                    sut.Output.Select(i => i.GetMetadata("TargetPath"))
+                );
+            }
+        }
+
+        private ITaskItem CreateContentItem(string path, IDictionary<string, string> metadata = null)
+        {
+            var item = new TaskItem(path);
+
+            if (metadata != null)
+            {
+                foreach (var kvp in metadata)
+                {
+                    item.SetMetadata(kvp.Key, kvp.Value);
+                }
+            }
+
+            return item;
+        }
+
+        private ITaskItem CreateModuleItem(string path, IDictionary<string, string> metadata = null)
+        {
+            var item = new TaskItem(path);
+
+            if (metadata != null)
+            {
+                foreach (var kvp in metadata)
+                {
+                    item.SetMetadata(kvp.Key, kvp.Value);
+                }
+            }
+
+            return item;
+        }
+    }
+}

--- a/src/tasks/RichardSzalay.Helix.Publishing.Tasks.Tests/RichardSzalay.Helix.Publishing.Tasks.Tests.csproj
+++ b/src/tasks/RichardSzalay.Helix.Publishing.Tasks.Tests/RichardSzalay.Helix.Publishing.Tasks.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="MergeXmlTransformsTests.cs" />
     <Compile Include="FakeFileSystem.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ResolveModuleContentTargetPathTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RichardSzalay.Helix.Publishing.Tasks\RichardSzalay.Helix.Publishing.Tasks.csproj">

--- a/src/tasks/RichardSzalay.Helix.Publishing.Tasks/ResolveModuleContentTargetPath.cs
+++ b/src/tasks/RichardSzalay.Helix.Publishing.Tasks/ResolveModuleContentTargetPath.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace RichardSzalay.Helix.Publishing.Tasks
+{
+    public class ResolveModuleContentTargetPath : Task
+    {
+        [Required]
+        public ITaskItem Module { get; set; }
+
+        [Required]
+        public ITaskItem[] Content { get; set; }
+
+        [Required]
+        public string TargetPathMetadataName { get; set; }
+
+        [Required]
+        public string ModuleMetadataPrefix { get; set; }
+
+        [Output]
+        public ITaskItem[] Output { get; set; }
+
+        public override bool Execute()
+        {
+            var output = new List<ITaskItem>();
+
+            foreach (var content in Content)
+            {
+                var resolvedTargetPath = ResolveTargetPath(content, Module);
+
+                if (Path.IsPathRooted(resolvedTargetPath) || resolvedTargetPath.StartsWith(".."))
+                {
+                    var contentFullPath = content.GetMetadata("FullPath");
+                    var targetPath = content.GetMetadata(TargetPathMetadataName);
+
+                    if (string.IsNullOrEmpty(targetPath))
+                    {
+                        Log.LogError($"Could not resolve {TargetPathMetadataName} for {contentFullPath}");
+                    }
+                    else
+                    {
+                        Log.LogError($"Could not resolve {TargetPathMetadataName} '{targetPath}' to a relative path for {contentFullPath}");
+                    }
+
+                    return false;
+                }
+                // TODO: Write error if resolvedTargetPath is absolute or starts with ..
+
+                var cloned = new TaskItem(content);
+
+                cloned.SetMetadata(TargetPathMetadataName, resolvedTargetPath);
+
+                output.Add(cloned);
+            }
+
+            Output = output.ToArray();
+
+            return true;
+        }
+
+        private string ResolveTargetPath(ITaskItem content, ITaskItem module)
+        {
+            var targetPathTemplate = content.GetMetadata(TargetPathMetadataName);
+
+            if (string.IsNullOrEmpty(targetPathTemplate))
+            {
+                return GetRelativePath(content, module);
+            }
+
+            return Regex.Replace(targetPathTemplate, @"\^\(([^)]+)\)", (match) =>
+            {
+                var key = match.Groups[1].Value;
+
+                if (key.StartsWith($"{ModuleMetadataPrefix}."))
+                {
+                    var moduleKey = key.Substring(ModuleMetadataPrefix.Length + 1);
+
+                    return module.GetMetadata(moduleKey);
+                }
+
+                if (content.MetadataNames.OfType<string>().Contains(key))
+                {
+                    return content.GetMetadata(key);
+                }
+
+                return content.GetMetadata(key);
+            });
+        }
+
+        private static string GetRelativePath(ITaskItem content, ITaskItem relativeTo)
+        {
+            // TODO: Throw if result is absolute
+            return MakeRelativePath(
+                relativeTo.GetMetadata("FullPath"),
+                content.GetMetadata("FullPath")                
+            );
+        }
+
+        private static string MakeRelativePath(string fromPath, string toPath)
+        {
+            if (string.IsNullOrEmpty(fromPath)) throw new ArgumentNullException("fromPath");
+            if (string.IsNullOrEmpty(toPath)) throw new ArgumentNullException("toPath");
+
+            Uri fromUri = new Uri(fromPath);
+            Uri toUri = new Uri(toPath);
+
+            if (fromUri.Scheme != toUri.Scheme) { return toPath; } // path can't be made relative.
+
+            Uri relativeUri = fromUri.MakeRelativeUri(toUri);
+            string relativePath = Uri.UnescapeDataString(relativeUri.ToString());
+
+            if (toUri.Scheme.Equals("file", StringComparison.InvariantCultureIgnoreCase))
+            {
+                relativePath = relativePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            }
+
+            return relativePath;
+        }
+    }
+}

--- a/src/tasks/RichardSzalay.Helix.Publishing.Tasks/RichardSzalay.Helix.Publishing.Tasks.csproj
+++ b/src/tasks/RichardSzalay.Helix.Publishing.Tasks/RichardSzalay.Helix.Publishing.Tasks.csproj
@@ -50,6 +50,7 @@
     <Compile Include="IFileSystem.cs" />
     <Compile Include="MergeXmlTransforms.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ResolveModuleContentTargetPath.cs" />
     <Compile Include="XmlTransformMerger.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
This PR adds supports for an alternate syntax for `AdditionalFilesForPackagingFromHelixModules` whereby both the `SourcePath` and `TargetPath` can both be specified individually. More information on the reasoning behind this development can be found in #18

It has two advantages over the original syntax (which is still supported):

* SourcePath doesn't need to be escaped
* TargetPath can map module + content metadata together to form a path 

Here's an example for adding `..\serialization` into a per-module folder within `App_Data\serialization`:

```xml
<!-- In ProjectName.wpp.targets or PublishProfile.wpp.targets -->
<ItemGroup>
  <AdditionalFilesForPackagingFromHelixModules Include="Serialization">
    <SourcePath>..\serialization\**\*.yml</SourcePath>
    <TargetPath>App_Data\unicorn\^(HelixModule.Filename)\^(RecursiveDir)^(Filename)^(Extension)</TargetPath>
  </AdditionalFilesForPackagingFromHelixModules>
</ItemGroup>
```

NOTE: The `^(HelixModule.Metadata)` syntax has access to any metadata defined on `HelixModulePaths` (which also copies all metadata from `ProjectReferences` by default). This allows custom metadata such as `<Layer>Feature</Layer>` to be used in the target path.