### PR TITLE
Remove additional files by pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,28 @@ Remapping the content to different output paths is currently not supported.
 
 NOTE: Web.config files contained in modules are intentionally skipped to avoid issues with long paths as described by [#9](https://github.com/richardszalay/helix-publishing-pipeline/issues/9). This restriction only affects Web.config files, not Sitecore config files, and will be removed once a suitable workaround is place.
 
+### Removing additional files
+
+It's quite common, particularly in development, to rename projects and config files. Unfortunately these typically remain in the deployment folder unless manually removed and can cause problems. Since the only built in option (DeleteExistingFiles) deletes _all_ target files, including `/sitecore` and always triggering an AppPool recycle, Helix Publishing Pipeline provides support for deleting target files specified by a pattern.
+
+The implementation only deletes additional files when they exist, skipping unnecessary AppPool recycles when no assemblies have changed.
+
+To use it, define `AdditionalFilesToRemoveFromTarget` with a file pattern in the `TargetPath` metadata:
+
+```xml
+<!-- In ProjectName.wpp.targets or PublishProfile.wpp.targets -->
+<ItemGroup>
+  <AdditionalFilesToRemoveFromTarget Include="ContosoAssemblies">
+    <TargetPath>bin\Contoso.*.dll</TargetPath>
+  </AdditionalFilesToRemoveFromTarget>
+  <AdditionalFilesToRemoveFromTarget Include="ContosoConfig">
+    <TargetPath>App_Config\**\Contoso.*.config</TargetPath>
+  </AdditionalFilesToRemoveFromTarget>
+</ItemGroup>
+```
+
+This feature is only currently supported when publishing to a FileSystem target, though a future release may support generating MSDeploy skip rules.
+
 ### Advanced scenarios
 
 Helix Publishing Pipeline has been developed using standard MSBuild conventions. As such, all functionality can be customised or disabled entirely. Review the [target files](https://github.com/richardszalay/helix-publishing-pipeline/tree/master/src/targets) for specifics.

--- a/src/targets/Helix.Publishing.Plugins/MergeHelixModuleWebConfigTransforms.targets
+++ b/src/targets/Helix.Publishing.Plugins/MergeHelixModuleWebConfigTransforms.targets
@@ -24,8 +24,11 @@
   <PropertyGroup>
     <HelixModuleWebConfigTransformFileNamePrefix>Web.Helix</HelixModuleWebConfigTransformFileNamePrefix>
 
+    <_HelixDefaultIntermediateOutputPath>$(IntermediateOutputPath)</_HelixDefaultIntermediateOutputPath>
+    <_HelixDefaultIntermediateOutputPath Condition="'$([System.IO.Path]::IsPathRooted($(IntermediateOutputPath)))' == 'False'">$(MSBuildProjectDirectory)\$(IntermediateOutputPath)</_HelixDefaultIntermediateOutputPath>
+
     <HelixTransformWebConfigIntermediateOutput Condition="'$(HelixTransformWebConfigIntermediateOutput)' == ''">HelixTransformWebConfig</HelixTransformWebConfigIntermediateOutput>
-    <HelixTransformWebConfigIntermediateLocation Condition="'$(HelixTransformWebConfigIntermediateLocation)' == ''">$(_WPPDefaultIntermediateOutputPath)$(HelixTransformWebConfigIntermediateOutput)</HelixTransformWebConfigIntermediateLocation>
+    <HelixTransformWebConfigIntermediateLocation Condition="'$(HelixTransformWebConfigIntermediateLocation)' == ''">$(_HelixDefaultIntermediateOutputPath)$(HelixTransformWebConfigIntermediateOutput)</HelixTransformWebConfigIntermediateLocation>
   </PropertyGroup>
 
   <Target Name="CollectHelixModuleWebConfigTransforms">

--- a/src/targets/Helix.Publishing.Plugins/RemoveAdditionalFiles.targets
+++ b/src/targets/Helix.Publishing.Plugins/RemoveAdditionalFiles.targets
@@ -1,0 +1,48 @@
+<Project>
+
+  <PropertyGroup>
+    <RemoveAdditionalFilesFromTarget Condition="'$(RemoveAdditionalFilesFromTarget)' == '' and '$(WebPublishMethod)' == 'FileSystem' and '$(PublishUrl)' != '' and '$(DeleteExistingFiles)' != 'true'">true</RemoveAdditionalFilesFromTarget>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <WebFileSystemPublishDependsOn Condition="'$(RemoveAdditionalFilesFromTarget)'=='true'">
+      $(WebFileSystemPublishDependsOn);
+      CollectAdditionalFilesToRemoveFromTarget
+    </WebFileSystemPublishDependsOn>
+  </PropertyGroup>
+
+  <Target Name="CollectAdditionalFilesToRemoveFromTarget" DependsOnTargets="CollectHelixModules">
+
+    <ItemGroup>
+      <_MatchingAdditionalFilesAtTargetBeforePublishSpecs Include="@(AdditionalFilesToRemoveFromTarget -> '$(PublishUrl)\%(TargetPath)')" />
+    </ItemGroup>
+
+    <CreateItem Include="@(_MatchingAdditionalFilesAtTargetBeforePublishSpecs)" PreserveExistingMetadata="true">
+        <Output TaskParameter="Include" ItemName="_MatchingAdditionalFilesAtTargetBeforePublish"/>
+    </CreateItem>
+
+    <CollectFilesinFolder RootPath="$(WPPAllFilesInSingleFolder)">
+      <Output TaskParameter="Result" ItemName="_MatchingAdditionalFilesAtSource" />
+    </CollectFilesinFolder>
+
+    <ItemGroup>
+      <MatchingFilesBeingUpdated Include="@(_MatchingAdditionalFilesAtSource -> '$(PublishUrl)\%(Identity)')" Condition="Exists('$(PublishUrl)\%(Identity)')" />
+
+      <_MatchingAdditionalFilesAtTargetBeforePublish Remove="@(MatchingFilesBeingUpdated)" />
+    </ItemGroup>
+
+    <Delete Files="@(_MatchingAdditionalFilesAtTargetBeforePublish)" />
+
+    <MakeDir Condition="$(EnablePackageProcessLoggingAndAssert) And !Exists($(PackageLogDir))"
+             Directories="$(PackageLogDir)" />
+
+    <WriteLinesToFile Condition="$(EnablePackageProcessLoggingAndAssert)"
+                      Encoding="utf-8"
+                      File="$(PackageLogDir)\AdditionalFilesToRemoveFromTarget.txt"
+                      Lines="@(_MatchingAdditionalFilesAtTargetBeforePublish->'
+                      Files:%(Identity)')"
+                      Overwrite="True" />
+
+  </Target>
+
+</Project>

--- a/src/targets/tests/RemoveAdditionalFiles.Tests.ps1
+++ b/src/targets/tests/RemoveAdditionalFiles.Tests.ps1
@@ -1,0 +1,54 @@
+. "$PSScriptRoot/utils/WebConfig.ps1"
+. "$PSScriptRoot/utils/MSBuild.ps1"
+. "$PSScriptRoot/utils/MSDeploy.ps1"
+
+$fixtures = @{
+    default = @{
+        Solution = "$PSScriptRoot\fixtures/default/HelixBuild.Sample.Web.sln";
+        Project1 = "$PSScriptRoot\fixtures/default/Projects\HelixBuild.Sample.Web\code\HelixBuild.Sample.Web.csproj";
+    }
+    
+}
+
+$count = 1
+
+Describe "AdditionalFilesToRemoveFromTarget" {
+
+    Context "include a file pattern to remove" {
+        $projectPath = $fixtures.default.Project1
+        $projectDir = Split-Path $projectPath -Parent
+
+        $outDir = Join-Path $PSScriptRoot "out"
+        $outBinDir = Join-Path $outDir "bin"
+
+        if (-not (Test-Path $outBinDir))
+        {
+            mkdir $outBinDir
+        }
+        Set-Content -Path (Join-Path $outBinDir "HelixBuild.Feature2.dll") -Value "test"
+        Set-Content -Path (Join-Path $outBinDir "HelixBuild.Foundation2.dll") -Value "test"
+        
+        Invoke-MSBuild -Project $projectPath -Properties @{
+            "HelixTargetsConfiguration" = "WebRoot"; # This is only supported by the test fixture
+            "Configuration" = "Debug";
+            "DeployOnBuild" = "true";
+            "DeployDefaultTarget" = "WebPublish";
+            "WebPublishMethod" = "FileSystem";
+            "PublishUrl" = $outDir;
+            "DeployAsIisApp" = "false";
+            "IncludeAdditionalFilesToRemoveFromTarget" = "true";
+        }
+
+        It "should remove matching files not being published" {
+            (Test-Path (Join-Path $outBinDir "HelixBuild.Feature2.dll")) | Should Be $false
+        }
+
+        It "should not remove matching files being published" {
+            (Test-Path (Join-Path $outBinDir "HelixBuild.Feature1.dll")) | Should Be $true
+        }
+
+        It "should not remove unmatched files" {
+            (Test-Path (Join-Path $outBinDir "HelixBuild.Foundation2.dll")) | Should Be $true
+        }
+    }
+}

--- a/src/targets/tests/fixtures/default/Projects/HelixBuild.Sample.Web/code/HelixBuild.Sample.Web.wpp.targets
+++ b/src/targets/tests/fixtures/default/Projects/HelixBuild.Sample.Web/code/HelixBuild.Sample.Web.wpp.targets
@@ -25,4 +25,10 @@
     <ItemGroup Condition="'$(IncludeFoundationAssemblyList)' == 'true'">
         <SitecoreAssemblyListsToExclude Include="AssemblyLists\FeatureList.txt" />
     </ItemGroup>
+
+    <ItemGroup Condition="'$(IncludeAdditionalFilesToRemoveFromTarget)' == 'true'">
+        <AdditionalFilesToRemoveFromTarget Include="Test">
+            <TargetPath>bin\HelixBuild.Feature*.dll</TargetPath>
+        </AdditionalFilesToRemoveFromTarget>
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
See #25 for more information.

This PR allows specific file patterns to be deleted if they're not included in the deployment. The implementation actually determines superfluous files, which avoids side effects like recycling the app pool when there's nothing to delete.

Currently only supported for FileSystem-based deployments, though there's room to generate MSDeploy rules based on the patterns in the future in order to support a number of other deployment types.

The syntax is as follows:

```xml
<!-- In ProjectName.wpp.targets or PublishProfile.wpp.targets -->
<ItemGroup>
  <AdditionalFilesToRemoveFromTarget Include="ContosoAssemblies">
    <TargetPath>bin\Contoso.*.dll</TargetPath>
  </AdditionalFilesToRemoveFromTarget>
  <AdditionalFilesToRemoveFromTarget Include="ContosoConfig">
    <TargetPath>App_Config\**\Contoso.*.config</TargetPath>
  </AdditionalFilesToRemoveFromTarget>
</ItemGroup>
```