### PR TITLE
Fix transform condition

### DIFF
--- a/src/targets/Helix.Publishing.Plugins/MergeHelixModuleWebConfigTransforms.targets
+++ b/src/targets/Helix.Publishing.Plugins/MergeHelixModuleWebConfigTransforms.targets
@@ -48,7 +48,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_MergeHelixWebConfigTransforms Condition="'@(HelixModuleWebConfigTransforms)' != '' or '$(IncludeHelixWebConfigTransformInPackage)' == 'true'">true</_MergeHelixWebConfigTransforms>
+      <_MergeHelixWebConfigTransforms Condition="'@(HelixModuleWebConfigTransforms)' != '' and '$(IncludeHelixWebConfigTransformInPackage)' == 'true'">true</_MergeHelixWebConfigTransforms>
       <_MergedHelixWebConfigTransform>$(HelixTransformWebConfigIntermediateLocation)\$(HelixModuleWebConfigTransformFileNamePrefix).config</_MergedHelixWebConfigTransform>
     </PropertyGroup>
 


### PR DESCRIPTION
I think the condition is wrong, I've tried to go on without any Web.Helix.config and setting the `IncludeHelixWebConfigTransformInPackage` to false, but I would always get the message `No transforms were supplied` at `packages\RichardSzalay.Helix.Publishing.WebRoot.1.4.1\build\Helix.Publishing.Plugins\MergeHelixModuleWebConfigTransforms.targets(55,5)`. I think this is because the `$(HelixModuleWebConfigTransforms)` always has a value, even though there are no files found.