### PR TITLE
Fix error when no Web.config transforms are available

### DIFF
--- a/src/targets/Helix.Publishing.Plugins/MergeHelixModuleWebConfigTransforms.targets
+++ b/src/targets/Helix.Publishing.Plugins/MergeHelixModuleWebConfigTransforms.targets
@@ -33,8 +33,8 @@
 
   <Target Name="CollectHelixModuleWebConfigTransforms">
     <ItemGroup>
-      <HelixModuleWebConfigTransforms Include="@(HelixModulePaths -> '%(RootDir)%(Directory)\$(HelixModuleWebConfigTransformFileNamePrefix).config')" />
-      <HelixModuleWebConfigTransforms Include="@(HelixModulePaths -> '%(RootDir)%(Directory)\$(HelixModuleWebConfigTransformFileNamePrefix).$(Configuration).config')" />
+      <HelixModuleWebConfigTransforms Include="@(HelixModulePaths -> '%(RootDir)%(Directory)$(HelixModuleWebConfigTransformFileNamePrefix).config')" />
+      <HelixModuleWebConfigTransforms Include="@(HelixModulePaths -> '%(RootDir)%(Directory)$(HelixModuleWebConfigTransformFileNamePrefix).$(Configuration).config')" />
     </ItemGroup>
   </Target>
 
@@ -42,28 +42,30 @@
 
     <ItemGroup>
       <_ProjectWebConfigTransform Include="@(WebConfigsToTransform)" Condition="'%(TransformScope)'==$([System.IO.Path]::GetFullPath($(WPPAllFilesInSingleFolder)\$(ProjectConfigFileName)))" />
-      <_WebConfigTransformsToMerge Include="@(HelixModuleWebConfigTransforms)" Condition="Exists(%(FullPath))" />
+      <_ValidHelixWebConfigTransforms Include="@(HelixModuleWebConfigTransforms)" Condition="Exists(%(FullPath))" />
+      <_WebConfigTransformsToMerge Include="@(_ValidHelixWebConfigTransforms)" />
       <_WebConfigTransformsToMerge Include="@(_ProjectWebConfigTransform->'%(TransformFile)')" Condition="Exists(%(_ProjectWebConfigTransform.TransformFile))" />
 
     </ItemGroup>
 
     <PropertyGroup>
-      <_MergeHelixWebConfigTransforms Condition="'@(HelixModuleWebConfigTransforms)' != '' or '$(IncludeHelixWebConfigTransformInPackage)' == 'true'">true</_MergeHelixWebConfigTransforms>
+      <_MergeHelixWebConfigTransforms Condition="'@(_ValidHelixWebConfigTransforms)' != '' or ('@(_WebConfigTransformsToMerge)' != '' and '$(IncludeHelixWebConfigTransformInPackage)' == 'true')">true</_MergeHelixWebConfigTransforms>
       <_MergedHelixWebConfigTransform>$(HelixTransformWebConfigIntermediateLocation)\$(HelixModuleWebConfigTransformFileNamePrefix).config</_MergedHelixWebConfigTransform>
     </PropertyGroup>
+
+    <Warning Condition="'$(_MergeHelixWebConfigTransforms)' != 'true' and '$(IncludeHelixWebConfigTransformInPackage)' == 'true'"
+      Text="Unable to include Web.config transform in package as there are no transforms to merge" />
 
     <MergeXmlTransforms Transforms="@(_WebConfigTransformsToMerge)"
                         OutputPath="$(_MergedHelixWebConfigTransform)"
                         Condition="'$(_MergeHelixWebConfigTransforms)'=='true'"
                         />
 
-    <ItemGroup Condition="'$(IncludeHelixWebConfigTransformInPackage)' == 'true'">
-      <FilesForPackagingFromProject Include="$(_MergedHelixWebConfigTransform)">
+    <ItemGroup Condition="'$(_MergeHelixWebConfigTransforms)' == 'true'">
+      <FilesForPackagingFromProject Include="$(_MergedHelixWebConfigTransform)" Condition="'$(IncludeHelixWebConfigTransformInPackage)' == 'true'">
         <DestinationRelativePath>$(HelixModuleWebConfigTransformFileNamePrefix).config</DestinationRelativePath>
       </FilesForPackagingFromProject>
-    </ItemGroup>
 
-    <ItemGroup Condition="'$(_MergeHelixWebConfigTransforms)' == 'true'">
       <WebConfigsToTransform Remove="@(_ProjectWebConfigTransform)" />
       <WebConfigsToTransform Include="@(_ProjectWebConfigTransform)">
         <TransformFile>$(_MergedHelixWebConfigTransform)</TransformFile>

--- a/src/targets/tests/fixtures/default/Features/HelixBuild.Feature1/code/HelixBuild.Feature1.csproj
+++ b/src/targets/tests/fixtures/default/Features/HelixBuild.Feature1/code/HelixBuild.Feature1.csproj
@@ -65,7 +65,7 @@
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>
-    <None Include="Web.Helix.config" />
+    <None Include="Web.Helix.config" Condition="'$(ExcludeHelixTransforms)' != 'true'" />
     <!-- This is intentionally marked as "content" for a unit test -->
     <Content Include="Web.Release.config">
       <DependentUpon>Web.config</DependentUpon>

--- a/src/targets/tests/fixtures/default/Foundation/HelixBuild.Foundation1/code/HelixBuild.Foundation1.csproj
+++ b/src/targets/tests/fixtures/default/Foundation/HelixBuild.Foundation1/code/HelixBuild.Foundation1.csproj
@@ -65,7 +65,7 @@
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>
-    <None Include="Web.Helix.config" />
+    <None Include="Web.Helix.config" Condition="'$(ExcludeHelixTransforms)' != 'true'" />
     <None Include="Web.Release.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>

--- a/src/targets/tests/fixtures/default/Projects/HelixBuild.Sample.Web/code/HelixBuild.Sample.Web.csproj
+++ b/src/targets/tests/fixtures/default/Projects/HelixBuild.Sample.Web/code/HelixBuild.Sample.Web.csproj
@@ -65,10 +65,10 @@
     <None Include="Properties\PublishProfiles\Package.pubxml">
       <SubType>Designer</SubType>
     </None>
-    <None Include="Web.Debug.config">
+    <None Include="Web.Debug.config" Condition="'$(ExcludeDefaultTransforms)' != 'true'">
       <DependentUpon>Web.config</DependentUpon>
     </None>
-    <None Include="Web.Release.config">
+    <None Include="Web.Release.config" Condition="'$(ExcludeDefaultTransforms)' != 'true'">
       <DependentUpon>Web.config</DependentUpon>
     </None>
   </ItemGroup>


### PR DESCRIPTION
Fixes an issue raised by PR #36 raised by @luuksommers. That PR fixed the symptom, but did so by disabling transforms when `IncludeHelixWebConfigTransformInPackage` was disabled.

This PR adds some additional checks and only performs the merged transform if there are valid helix transforms _or_ if there is a standard transform and IncludeHelixWebConfigTransformInPackage is enabled.