### PR TITLE
Support assembly list 'header' rows

### DIFF
--- a/src/tasks/RichardSzalay.Helix.Publishing.Tasks.Tests/AssemblyListParserTests.cs
+++ b/src/tasks/RichardSzalay.Helix.Publishing.Tasks.Tests/AssemblyListParserTests.cs
@@ -120,6 +120,43 @@ Asm2,2.0,3.0",
         }
 
         [Fact]
+        public void EmptyHeaderRows_AreSkipped()
+        {
+            Test(
+                input: @"
+FileVersion,AssemblyVersion,Assembly
+Asm1,1.0,2.0
+
+Asm2,2.0,3.0",
+
+                expected: new List<AssemblyListEntry>
+                {
+                    CreateAssemblyListEntry("Asm1", "1.0", "2.0"),
+                    CreateAssemblyListEntry("Asm2", "2.0", "3.0")
+                }
+            );
+        }
+
+        [Fact]
+        public void TitleHeaderRows_AreSkipped()
+        {
+            Test(
+                input: @"
+XConnect Assembly List
+FileVersion,AssemblyVersion,Assembly
+Asm1,1.0,2.0
+
+Asm2,2.0,3.0",
+
+                expected: new List<AssemblyListEntry>
+                {
+                    CreateAssemblyListEntry("Asm1", "1.0", "2.0"),
+                    CreateAssemblyListEntry("Asm2", "2.0", "3.0")
+                }
+            );
+        }
+
+        [Fact]
         public void InvalidRows_StopsProcessing()
         {
             Test(

--- a/src/tasks/RichardSzalay.Helix.Publishing.Tasks/AssemblyListParser.cs
+++ b/src/tasks/RichardSzalay.Helix.Publishing.Tasks/AssemblyListParser.cs
@@ -65,38 +65,40 @@ namespace RichardSzalay.Helix.Publishing.Tasks
         {
             headers = null;
             options = null;
-
+            
             var line = readNonEmptyLine();
 
-            if (line == null)
-                return false;
-
-            if (TryParseOptions(line, out options))
+            while (line != null)
             {
-                line = readNonEmptyLine();
-            }
-
-            if (line == null)
-                return false;
-
-            if (options == null)
-            {
-                var separator = GuessSeparator(line);
-
-                if (separator == null)
+                if (TryParseOptions(line, out options))
                 {
-                    // TODO: Log
-                    return false;
+                    line = readNonEmptyLine();
                 }
 
-                options = new AssemblyListOptions
+                if (line == null)
+                    return false;
+
+                if (options == null)
                 {
-                    Separator = GuessSeparator(line)
-                };
+                    var separator = GuessSeparator(line);
+
+                    if (separator == null)
+                    {
+                        line = readNonEmptyLine();
+                        continue;
+                    }
+
+                    options = new AssemblyListOptions
+                    {
+                        Separator = GuessSeparator(line)
+                    };
+                }
+
+                headers = ParseLine(line, options);
+                return true;
             }
 
-            headers = ParseLine(line, options);
-            return true;
+            return false;
         }
 
         private string[] ParseLine(string line, AssemblyListOptions options)
@@ -112,7 +114,7 @@ namespace RichardSzalay.Helix.Publishing.Tasks
             if (headerLine.Contains(','))
                 return ",";
 
-            throw new ArgumentException("Unable to determine separator");
+            return null;
         }
 
         private bool TryParseOptions(string line, out AssemblyListOptions options)


### PR DESCRIPTION
As used by XConnect in 9.1.

eg.

```

Sitecore XConnect Server
Filename,FileVersion,Version
Microsoft.Azure.SqlDatabase.ElasticScale.Client.dll,1.3.3.1,1.3.0.0
```