### PR TITLE
Fix RemoveAdditionalFilesFromTarget in non-test scenarios

### DIFF
--- a/src/targets/Helix.Publishing.Plugins/RemoveAdditionalFiles.targets
+++ b/src/targets/Helix.Publishing.Plugins/RemoveAdditionalFiles.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <RemoveAdditionalFilesFromTarget Condition="'$(RemoveAdditionalFilesFromTarget)' == '' and '$(WebPublishMethod)' == 'FileSystem' and '$(PublishUrl)' != '' and '$(DeleteExistingFiles)' != 'true'">true</RemoveAdditionalFilesFromTarget>
+    <RemoveAdditionalFilesFromTarget Condition="'$(RemoveAdditionalFilesFromTarget)' == '' and '$(DeleteExistingFiles)' != 'true'">true</RemoveAdditionalFilesFromTarget>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The conditions for auto-enabling the feature were too reliant on the properties set by the test fixture project.

Fixes #52