### PR TITLE
PackageReference compatiblity

### DIFF
--- a/src/targets/Helix.Publishing.Plugins/ExcludeUnchangedConfigFiles.targets
+++ b/src/targets/Helix.Publishing.Plugins/ExcludeUnchangedConfigFiles.targets
@@ -10,14 +10,14 @@
               />
 
   <PropertyGroup>
-    <PipelineTransformPhaseDependsOn Condition="'$(ExcludeUnchangedConfigFilesFromPublish)'=='true'">
+    <PipelineTransformPhaseDependsOn Condition="'$(ExcludeUnchangedConfigFilesFromPublish)'=='truasde'">
       $(PipelineTransformPhaseDependsOn);
       ExcludeUnchangedConfigFilesFromPublish
     </PipelineTransformPhaseDependsOn>
   </PropertyGroup>
 
   <!-- Content item (ie csproj) implementation of CollectFilesFromHelixModules -->
-  <Target Name="ExcludeUnchangedConfigFilesFromPublish" DependsOnTargets="CollectHelixModules">
+  <Target Name="ExcludeUnchangedConfigFilesFromPublish" BeforeTargets="PipelineTransformPhase" DependsOnTargets="CollectHelixModules" Condition="'$(ExcludeUnchangedConfigFilesFromPublish)'=='true'">
     <ItemGroup>
       <_ConfigFilesForPotentialExclusion 
         Include="@(FilesForPackagingFromProject)" 

--- a/src/targets/Helix.Publishing.Plugins/MergeHelixModuleWebConfigTransforms.targets
+++ b/src/targets/Helix.Publishing.Plugins/MergeHelixModuleWebConfigTransforms.targets
@@ -11,10 +11,6 @@
               />
 
   <PropertyGroup>
-    <PreTransformWebConfigDependsOn Condition="'$(MergeHelixModuleWebConfigTransforms)'=='true'">
-      $(PreTransformWebConfigDependsOn);
-      MergeHelixModuleWebConfigTransforms
-    </PreTransformWebConfigDependsOn>
     <MergeHelixModuleWebConfigTransformsDependsOn>
       $(MergeHelixModuleWebConfigTransformsDependsOn);
       CollectHelixModuleWebConfigTransforms
@@ -38,7 +34,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="MergeHelixModuleWebConfigTransforms" DependsOnTargets="$(MergeHelixModuleWebConfigTransformsDependsOn)">
+  <Target Name="MergeHelixModuleWebConfigTransforms" BeforeTargets="PreTransformWebConfig" DependsOnTargets="$(MergeHelixModuleWebConfigTransformsDependsOn)" Condition="'$(MergeHelixModuleWebConfigTransforms)'=='true'">
 
     <ItemGroup>
       <_ProjectWebConfigTransform Include="@(WebConfigsToTransform)" Condition="'%(TransformScope)'==$([System.IO.Path]::GetFullPath($(WPPAllFilesInSingleFolder)\$(ProjectConfigFileName)))" />

--- a/src/targets/tests/fixtures/default/Projects/HelixBuild.Sample.Web/code/HelixBuild.Sample.Web.csproj
+++ b/src/targets/tests/fixtures/default/Projects/HelixBuild.Sample.Web/code/HelixBuild.Sample.Web.csproj
@@ -90,13 +90,15 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <PropertyGroup>
     <HelixTargetsConfiguration Condition="'$(HelixTargetsConfiguration)'==''">WebRoot</HelixTargetsConfiguration>
   </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\..\..\RichardSzalay.Helix.Publishing.$(HelixTargetsConfiguration).targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  
+  
   <ProjectExtensions>
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">


### PR DESCRIPTION
#54 made me realise that there could be a number of issues that arise from running via `PackageReference` since the targets file is include before the Web.Application.targets so patching `XXXDependsOn` might result in things running too early.

I was right and two issues arose:

* Merged transforms (Web.Helix.config) didn't work
* Skipping unchanged transformed Web.config files didn't work

This PR resolves both these issues and moves the test fixture import before the Web.Application.targets import in order to raise any future compatibility issues that might crop up.