### PR TITLE
Allow external MatchSourceMetadataName

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Alternatively, additional module metadata can be extracted based on module namin
   <HelixModuleMetadataPatterns Include="Convention">
     <!-- Now available as ^(HelixModule.Namespace), ^(HelixModule.Layer), and ^(HelixModule.Module) -->
     <Pattern>^(?'Namespace'.+)\.(?'Layer'.+?)\.(?'Module'.+)$</Pattern>
+    <!-- Uncomment the following line to use a different Source to match the regex upon (e.g. FileName) -->
+    <!-- <SourceMetadataName>FileName</SourceMetadataName> -->
   </HelixModuleMetadataPatterns>
 </ItemGroup>
 ```

--- a/src/targets/Helix.Publishing.Plugins/CollectHelixModuleMetadata.targets
+++ b/src/targets/Helix.Publishing.Plugins/CollectHelixModuleMetadata.targets
@@ -17,8 +17,8 @@
   >
   
     <PropertyGroup>
+      <!-- The task defaults to the value Name -->
       <MatchSourceMetadataName>%(HelixModuleMetadataPatterns.SourceMetadataName)</MatchSourceMetadataName>
-      <MatchSourceMetadataName>Name</MatchSourceMetadataName>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/targets/Helix.Publishing.Plugins/CollectHelixModuleMetadata.targets
+++ b/src/targets/Helix.Publishing.Plugins/CollectHelixModuleMetadata.targets
@@ -19,6 +19,7 @@
     <PropertyGroup>
       <!-- The task defaults to the value Name -->
       <MatchSourceMetadataName>%(HelixModuleMetadataPatterns.SourceMetadataName)</MatchSourceMetadataName>
+      <MatchSourceMetadataName Condition="'$(MatchSourceMetadataName)' == ''">Name</MatchSourceMetadataName>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
I think the MatchSourceMetadataName should not be in there twice as I am unable to update the MatchSourceMetadataNeme from the HelixModuleMetadataPatterns like

```xml
<HelixModuleMetadataPatterns Include="Convention">
  <!-- Now available as ^(HelixModule.Namespace), ^(HelixModule.Layer), and ^(HelixModule.Module) -->
  <SourceMetadataName>FileName</SourceMetadataName>
  <Pattern>^(?'Company'.+)\.(?'Solution'.+)\.(?'Project'.+?)\.(?'Module'.+)$</Pattern>
</HelixModuleMetadataPatterns>
```

The task already defaults to Name so I guess this is not needed, or should I add a condition so the target also defaults to Name when it's empty?