### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Individual assemblies can also be whitelisted (for example, if a patched version
 
 Unless otherwise specified, customisations should be either made to `ProjectName.wpp.targets` (to apply to all profiles) or `PublishProfileName.wpp.targets` (to apply to a single profile).
 
+> Please note that the `PublishProfileName.wpp.targets` must be in the same folder as the `PublishProfileName.pubxml` file and the `ProjectName.wpp.targets` must be in the same folder as your .csproj.
+
 ### Defining `Web.config` transforms
 
 Every module can define their own `Web.Helix.config` transform file to apply config transforms to the web root's `Web.config` file during publishing.


### PR DESCRIPTION
Make it clear that the .wpp.targets should be in the right locations. I had both publish profiles in the root and they both got executed all the time. 

From Microsoft.Web.Publishing.targets:
```xml
<PropertyGroup Condition="'$(_WebPublishProfileFileWillBeImported)'=='true'">
    <WebPublishProfileCustomizeTargetFile Condition="'$(WebPublishProfileCustomizeTargetFile)'==''">$([System.IO.Path]::ChangeExtension($(WebPublishProfileFile), '.wpp.targets'))</WebPublishProfileCustomizeTargetFile>
    <WebPublishProfileParametersXMLFile Condition="'$(WebPublishProfileParametersXMLFile)'==''">$([System.IO.Path]::ChangeExtension($(WebPublishProfileFile), '.parameters.xml'))</WebPublishProfileParametersXMLFile>
  </PropertyGroup>

  <Import Project="$(WebPublishProfileCustomizeTargetFile)" Condition="'$(WebPublishProfileCustomizeTargetFile)' != '' And Exists($(WebPublishProfileCustomizeTargetFile)) " />

  <!--***************************************************************-->
  <!-- If there is a file named $(WebPublishPipelineProjectName).wpp.targets it will automatically be imported. -->
  <!-- This allows users to extend the build/publish process for the project -->
  <!--***************************************************************-->
  <PropertyGroup>
    <WebPublishPipelineCustomizeTargetFile Condition="'$(WebPublishPipelineCustomizeTargetFile)'==''">$(WebPublishPipelineProjectDirectory)\*.wpp.targets</WebPublishPipelineCustomizeTargetFile>
    <WebPublishPipelineSolutionTargetFile Condition="'$(WebPublishPipelineSolutionTargetFile)'==''">$(WebPublishPipelineProjectDirectory)\..\wpp.deploysettings.targets</WebPublishPipelineSolutionTargetFile>
  </PropertyGroup>
```